### PR TITLE
Fix broken assert that used pointer as reference

### DIFF
--- a/src/Query.cc
+++ b/src/Query.cc
@@ -91,7 +91,7 @@ bool query_passes(BloomTree* root, const std::set<jellyfish::mer_dna> & q) {
 // return true if the filter at this node contains > QUERY_THRESHOLD kmers
 bool query_passes(BloomTree* root, QueryInfo*  q) {//const std::set<jellyfish::mer_dna> & q) {
     float weight = 1.0;
-    assert(q.size() > 0);
+    assert(q != NULL && q->query.size() > 0);
     auto bf = root->bf();
     float c = 0;
     unsigned n = 0;


### PR DESCRIPTION
Hi all,

I tried compiling with debugging enabled to debug a segfault, and hit a compilation error. The attached patch seemed to fix the initial compile error, I'm still working on the segfault.

Cheers,
Kevin
